### PR TITLE
Add hash-bench-nds to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ As this list is written with developers in mind, this section only lists such pr
 ### Demos
 
 * [tuna-viDS](https://github.com/chishm/tuna-vids) (GPLv2) - XviD video player
+* [hash-bench-nds](https://github.com/dmang-dev/hash-bench-nds) (MIT) - Hash-algorithm benchmark that times 32 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, BLAKE2s, etc.) on the ARM946E and displays µs/iter and KB/s across both screens, using libnds
 
 ### Other Homebrew
 


### PR DESCRIPTION
## What this PR does

Adds a single entry to **Open-source Homebrew → Demos**:

```markdown
* [hash-bench-nds](https://github.com/dmang-dev/hash-bench-nds) (MIT) - Hash-algorithm benchmark that times 32 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, BLAKE2s, etc.) on the ARM946E and displays µs/iter and KB/s across both screens, using libnds
```

## Why "Demos"

It's a self-contained homebrew that demonstrates what the DS can do with a technical workload, sitting naturally next to `tuna-viDS` (XviD video player) — both are technical demonstrations rather than games or applications. The entry follows the section's existing format including the `(LICENSE)` tag.

## Project at a glance

- **Repo:** https://github.com/dmang-dev/hash-bench-nds
- **v1.0.0 release with prebuilt `.nds`:** https://github.com/dmang-dev/hash-bench-nds/releases/tag/v1.0.0
- **License:** MIT
- **Built with:** devkitARM + libnds 2.0.2 (Calico runtime)
- **Tested in:** melonDS 1.1

## Disclosure

I'm the author.
